### PR TITLE
fix(indexing): add PHP to enabled languages in file walker

### DIFF
--- a/src/indexing/walker.rs
+++ b/src/indexing/walker.rs
@@ -87,6 +87,7 @@ impl FileWalker {
             Language::Python,
             Language::JavaScript,
             Language::TypeScript,
+            Language::Php,
         ]
         .into_iter()
         .filter(|&lang| {


### PR DESCRIPTION
PHP files were not being picked up during directory indexing because the walker's get_enabled_languages() method didn't include Language::Php in the list of supported languages.